### PR TITLE
Use NINAB31 for senseBox MCU S2

### DIFF
--- a/src/phyphoxBLE_ESP32.cpp
+++ b/src/phyphoxBLE_ESP32.cpp
@@ -1,4 +1,4 @@
-#ifdef ESP32
+#if defined(ESP32) && !defined(ARDUINO_SENSEBOX_MCU_ESP32S2)
 #include "phyphoxBLE_ESP32.h"
 #include "Arduino.h"
 #include <stdio.h>
@@ -99,8 +99,8 @@ class MyCharCallback: public BLECharacteristicCallbacks {
     PhyphoxBLE* myServerPointer;
     void onWrite(BLECharacteristic *pCharacteristic) {
                  PhyphoxBLE::configHandlerDebug();
-      
-    }      
+
+    }
 };
 
 class MyServerCallbacks: public BLEServerCallbacks {
@@ -118,7 +118,7 @@ class MyServerCallbacks: public BLEServerCallbacks {
 void PhyphoxBLE::configHandlerDebug(){
   if(configHandler!=nullptr){
     (*configHandler)();
-  }  
+  }
 }
 
 void PhyphoxBLE::eventCharacteristicHandler(){
@@ -132,14 +132,14 @@ void PhyphoxBLE::eventCharacteristicHandler(){
   PhyphoxBLE::experimentTime = swap_int64(et);
   if(experimentEventHandler!=nullptr){
     (*experimentEventHandler)();
-  }  
+  }
 }
 
 void PhyphoxBLE::setMTU(uint16_t mtuSize) {
     BLEDevice::setMTU(mtuSize+3); //user mtu size + 3 for overhead
-    
+
     PhyphoxBLE::MTU = mtuSize;
-    PhyphoxBleExperiment::MTU = mtuSize;  
+    PhyphoxBleExperiment::MTU = mtuSize;
 }
 
 void PhyphoxBLE::start(const char* DEVICE_NAME, uint8_t* exp_pointer, size_t len){
@@ -169,18 +169,18 @@ void PhyphoxBLE::start(const char * DEVICE_NAME)
           PhyphoxBleExperiment::View firstView;
 
           //Graph
-          PhyphoxBleExperiment::Graph firstGraph;      //Create graph which will plot random numbers over time     
-          firstGraph.setChannel(0,1);    
+          PhyphoxBleExperiment::Graph firstGraph;      //Create graph which will plot random numbers over time
+          firstGraph.setChannel(0,1);
 
           //Value
           PhyphoxBleExperiment::Value valueField;
           valueField.setChannel(1);
 
           firstView.addElement(firstGraph);
-          firstView.addElement(valueField);    
+          firstView.addElement(valueField);
           defaultExperiment.addView(firstView);
-          
-          addExperiment(defaultExperiment);  
+
+          addExperiment(defaultExperiment);
     }
 
 	BLEDevice::init(DEVICE_NAME);
@@ -192,12 +192,12 @@ void PhyphoxBLE::start(const char * DEVICE_NAME)
           phyphoxBleExperimentCharacteristicUUID,
           BLECharacteristic::PROPERTY_READ   |
            BLECharacteristic::PROPERTY_WRITE |
-           BLECharacteristic::PROPERTY_NOTIFY 
-      );  
+           BLECharacteristic::PROPERTY_NOTIFY
+      );
   eventCharacteristic = phyphoxExperimentService->createCharacteristic(
           phyphoxBleEventCharacteristicUUID,
           BLECharacteristic::PROPERTY_WRITE
-      );      
+      );
 
   phyphoxDataService = myServer->createService(phyphoxBleDataServiceUUID);
 
@@ -205,7 +205,7 @@ void PhyphoxBLE::start(const char * DEVICE_NAME)
 	     phyphoxBleDataCharacteristicUUID,
 	     BLECharacteristic::PROPERTY_READ |
 	     BLECharacteristic::PROPERTY_WRITE |
-	     BLECharacteristic::PROPERTY_NOTIFY 
+	     BLECharacteristic::PROPERTY_NOTIFY
 
 	   );
 
@@ -213,7 +213,7 @@ void PhyphoxBLE::start(const char * DEVICE_NAME)
           phyphoxBleConfigCharacteristicUUID,
           BLECharacteristic::PROPERTY_READ   |
            BLECharacteristic::PROPERTY_WRITE |
-           BLECharacteristic::PROPERTY_NOTIFY 
+           BLECharacteristic::PROPERTY_NOTIFY
       );
 
   myExperimentDescriptor = new BLE2902();
@@ -226,12 +226,12 @@ void PhyphoxBLE::start(const char * DEVICE_NAME)
   myDataDescriptor->setCallbacks(new MyDataCallback());
   eventCharacteristic->setCallbacks(new MyEventCallback());
   configCharacteristic->setCallbacks(new MyCharCallback());
-  
+
   dataCharacteristic->addDescriptor(myDataDescriptor);
   experimentCharacteristic->addDescriptor(myExperimentDescriptor);
   eventCharacteristic->addDescriptor(myEventDescriptor);
   configCharacteristic->addDescriptor(myConfigDescriptor);
-  
+
 
   phyphoxExperimentService->start();
   phyphoxDataService->start();
@@ -255,7 +255,7 @@ void PhyphoxBLE::poll(int timeout) {
 void PhyphoxBLE::staticStartTask(void* _this){
 	PhyphoxBLE::when_subscription_received();
   delay(1);
-}	
+}
 
 void PhyphoxBLE::startTask()
 {
@@ -267,8 +267,8 @@ void PhyphoxBLE::write(float& value)
 {
   /**
    * \brief Write a single float into characteristic
-     * The float is parsed to uint8_t* 
-     * because the gattServer write method 
+     * The float is parsed to uint8_t*
+     * because the gattServer write method
      * expects a pointer to uint8_t
      * \param f1 represent a float most likeley sensor data
     */
@@ -380,17 +380,17 @@ void PhyphoxBLE::when_subscription_received()
     experimentSizeArray[0]=  (arrayLength >> 24);
     experimentSizeArray[1]=  (arrayLength >> 16);
     experimentSizeArray[2]=  (arrayLength >> 8);
-    experimentSizeArray[3]=  arrayLength; 
+    experimentSizeArray[3]=  arrayLength;
 
     uint8_t checksumArray[4] = {0};
     checksumArray[0]= (checksum >> 24) & 0xFF;
-    checksumArray[1]= (checksum >> 16) & 0xFF;  
+    checksumArray[1]= (checksum >> 16) & 0xFF;
     checksumArray[2]= (checksum >> 8) & 0xFF;
-    checksumArray[3]= checksum & 0xFF; 
+    checksumArray[3]= checksum & 0xFF;
 
     copy(phyphox, phyphox+7, header);
     copy(experimentSizeArray, experimentSizeArray+ 4, header + 7);
-    copy(checksumArray, checksumArray +  4, header +11); 
+    copy(checksumArray, checksumArray +  4, header +11);
     experimentCharacteristic->setValue(header,sizeof(header));
     experimentCharacteristic->notify();
 
@@ -398,22 +398,22 @@ void PhyphoxBLE::when_subscription_received()
         copy(exp+i*20, exp+i*20+20, header);
         experimentCharacteristic->setValue(header,sizeof(header));
         experimentCharacteristic->notify();
-		    delay(10);// mh does not work anymore with 1ms delay?!   
+		    delay(10);// mh does not work anymore with 1ms delay?!
 	}
-  
+
 	if(exp_len%20 != 0){
 		const size_t rest = exp_len%20;
 		uint8_t slice[rest];
 		copy(exp + exp_len - rest, exp + exp_len, slice);
 		experimentCharacteristic->setValue(slice,sizeof(slice));
-		experimentCharacteristic->notify();        
+		experimentCharacteristic->notify();
 		delay(1);
 	}
- 
+
 
 	myAdvertising->start();
-  
-  
+
+
 	vTaskDelete( NULL );
 
 }
@@ -423,7 +423,7 @@ void PhyphoxBLE::addExperiment(PhyphoxBleExperiment& exp)
   {
     storage[i]=0;
   }
-  
+
   exp.getFirstBytes(EXPARRAY, deviceName);
 	for(uint8_t i=0;i<phyphoxBleNViews; i++){
 		for(int j=0; j<phyphoxBleNElements; j++){
@@ -450,8 +450,8 @@ void PhyphoxBLE::begin(HardwareSerial* hwPrint)
   #ifdef DEBUG
 	printer = hwPrint;
   if(printer)
-	   printer->begin(115200);       
-  #endif  
+	   printer->begin(115200);
+  #endif
 }
 
 void PhyphoxBLE::printXML(HardwareSerial* printer){

--- a/src/phyphoxBLE_NINAB31.cpp
+++ b/src/phyphoxBLE_NINAB31.cpp
@@ -1,9 +1,9 @@
-#if defined(ARDUINO_SAMD_MKR1000)
+#if defined(ARDUINO_SAMD_MKR1000) || defined(ARDUINO_SENSEBOX_MCU_ESP32S2)
 
 #include "phyphoxBle.h"
 #include "NINAB31serial.h"
 #include "Arduino.h"
-#include <stdio.h> 
+#include <stdio.h>
 /*
 BLEService PhyphoxBLE::phyphoxExperimentService{phyphoxBleExperimentServiceUUID}; // create service
 BLECharacteristic PhyphoxBLE::experimentCharacteristic{phyphoxBleExperimentCharacteristicUUID, BLERead | BLEWrite| BLENotify, 20, false};
@@ -60,44 +60,44 @@ void PhyphoxBLE::start(const char* DEVICE_NAME)
 {
     port.begin();
     port.stopAdvertise();
-    
+
     port.checkResponse("AT+UBTAD=020A0605121800280011074A5153BA405E438B7146F7300100DFCD",1000);
     h_phyphoxExperimentService=port.parseResponse("AT+UBTGSER=CDDF000130F746718B435E40BA53514A",1000);
     h_controlCharacteristic=port.parseResponse("AT+UBTGCHA=CDDF000330F746718B435E40BA53514A,1a,1,1",1000);
     h_experimentCharacteristic=port.parseResponse("AT+UBTGCHA=CDDF000230F746718B435E40BA53514A,1a,1,1",1000);
-    
+
     h_phyphoxDataService=port.parseResponse("AT+UBTGSER=CDDF100130F746718B435E40BA53514A",1000);
     h_dataCharacteristic=port.parseResponse("AT+UBTGCHA=CDDF100230F746718B435E40BA53514A,1a,1,1",1000);
     h_configCharacteristic=port.parseResponse("AT+UBTGCHA=CDDF100330F746718B435E40BA53514A,1a,1,1",1000);
-    
-    
+
+
 
 	if(p_exp == nullptr){
-  
+
       PhyphoxBleExperiment defaultExperiment;
 
       //View
       PhyphoxBleExperiment::View firstView;
 
       //Graph
-      PhyphoxBleExperiment::Graph firstGraph;      //Create graph which will plot random numbers over time     
-      firstGraph.setChannel(0,1);    
+      PhyphoxBleExperiment::Graph firstGraph;      //Create graph which will plot random numbers over time
+      firstGraph.setChannel(0,1);
 
-      firstView.addElement(firstGraph);       
+      firstView.addElement(firstGraph);
       defaultExperiment.addView(firstView);
-      
-     addExperiment(defaultExperiment);  
+
+     addExperiment(defaultExperiment);
   }
-  
-  
-  
-  
+
+
+
+
   // set connection parameter
   port.setConnectionInterval(minConInterval, maxConInterval);
   port.checkResponse("AT+UBTAD=020A0605121800280011074A5153BA405E438B7146F7300100DFCD",1000);
   port.advertise();
   port.setLocalName(DEVICE_NAME);
-  
+
 }
 
 void PhyphoxBLE::start() {
@@ -146,7 +146,7 @@ void PhyphoxBLE::addExperiment(PhyphoxBleExperiment& exp)
     }
   }
   exp.getLastBytes(buffer);
-  
+
 	memcpy(&EXPARRAY[length],&buffer[0],strlen(buffer));
   length += strlen(buffer);
 	p_exp = &EXPARRAY[0];
@@ -233,7 +233,7 @@ void PhyphoxBLE::poll(){
         }
         port.flushInput();
     }
-    
+
 }
 
 void PhyphoxBLE::controlCharacteristicWritten() {
@@ -245,9 +245,9 @@ void PhyphoxBLE::controlCharacteristicWritten() {
   } else {
     //experiment transfered
     exploaded=true;
-    
+
   }
-  
+
 }
 
 void PhyphoxBLE::transferExperiment(){
@@ -267,19 +267,19 @@ void PhyphoxBLE::transferExperiment(){
   experimentSizeArray[0]=  (arrayLength >> 24);
   experimentSizeArray[1]=  (arrayLength >> 16);
   experimentSizeArray[2]=  (arrayLength >> 8);
-  experimentSizeArray[3]=  arrayLength; 
+  experimentSizeArray[3]=  arrayLength;
 
   uint8_t checksumArray[4] = {0};
   checksumArray[0]= (checksum >> 24) & 0xFF;
-  checksumArray[1]= (checksum >> 16) & 0xFF;  
+  checksumArray[1]= (checksum >> 16) & 0xFF;
   checksumArray[2]= (checksum >> 8) & 0xFF;
-  checksumArray[3]= checksum & 0xFF; 
+  checksumArray[3]= checksum & 0xFF;
 
   memcpy(&header[0],&phyphox[0],7);
   memcpy(&header[0]+7,&experimentSizeArray[0],4);
   memcpy(&header[0]+7+4,&checksumArray[0],4);
   port.writeValue(h_experimentCharacteristic,header,sizeof(header));
-  
+
   for(size_t i = 0; i < exp_len/20; ++i){
     memcpy(&header[0],&exp[0]+i*20,20);
     port.writeValue(h_experimentCharacteristic,header,sizeof(header));
@@ -293,7 +293,7 @@ if(exp_len%20 != 0){
   port.writeValue(h_experimentCharacteristic,slice,sizeof(slice));
 }
   exploaded=true;
-    
+
   port.advertise();
 }
 

--- a/src/phyphoxBle.h
+++ b/src/phyphoxBle.h
@@ -45,13 +45,13 @@ static const char *deviceName = "phyphox-Arduino";
 #ifndef CONFIGSIZE
 #define CONFIGSIZE 20
 #endif
-#if defined(ARDUINO_SAMD_MKR1000)
+#if defined(ARDUINO_SAMD_MKR1000) || defined(ARDUINO_SENSEBOX_MCU_ESP32S2)
     #include "phyphoxBLE_NINAB31.h"
 #elif defined(ARDUINO_ARCH_MBED)
     #include "phyphoxBLE_NRF52.h"
 
 
-#elif defined(ESP32)
+#elif defined(ESP32) && !defined(ARDUINO_SENSEBOX_MCU_ESP32S2)
     #include "phyphoxBLE_ESP32.h"
 #elif defined(ARDUINO_SAMD_NANO_33_IOT) || defined(ARDUINO_UNOR4_WIFI)
     #include <ArduinoBLE.h>
@@ -67,10 +67,10 @@ struct phyphoxBleCrc32
     static void generate_table(uint32_t(&table)[256])
     {
         uint32_t polynomial = 0xEDB88320;
-        for (uint32_t i = 0; i < 256; i++) 
+        for (uint32_t i = 0; i < 256; i++)
         {
             uint32_t c = i;
-            for (size_t j = 0; j < 8; j++) 
+            for (size_t j = 0; j < 8; j++)
             {
                 if (c & 1) {
                     c = polynomial ^ (c >> 1);
@@ -87,7 +87,7 @@ struct phyphoxBleCrc32
     {
         uint32_t c = initial ^ 0xFFFFFFFF;
         const uint8_t* u = static_cast<const uint8_t*>(buf);
-        for (size_t i = 0; i < len; ++i) 
+        for (size_t i = 0; i < len; ++i)
         {
             c = table[(c ^ u[i]) & 0xFF] ^ (c >> 8);
         }


### PR DESCRIPTION
This PR enables phyphox on the new [senseBox MCU S2](https://sensebox.shop/product/sensebox-mcu-s2-icm) (based on ESP32 S2) with the existing [senseBox BLE Bee](https://sensebox.shop/product/bluetooth-bee) (based on NINA B1), as the ESP32 S2 does not have Bluetooth on board. 

We can identify the MCU S2 by checking if `ARDUINO_SENSEBOX_MCU_ESP32S2` is defined. Thus, the board is distinguishable with all other ESP32 boards. If `ARDUINO_SENSEBOX_MCU_ESP32S2` is defined, the library now also uses the `phyphoxBLE_NINAB31` logic. 

Tested with ESP32, senseBox MCU and senseBox MCU S2