### PR TITLE
Add support for Boards using NimBLE

### DIFF
--- a/src/phyphoxBLE_ESP32.cpp
+++ b/src/phyphoxBLE_ESP32.cpp
@@ -104,11 +104,18 @@ class MyCharCallback: public BLECharacteristicCallbacks {
 };
 
 class MyServerCallbacks: public BLEServerCallbacks {
+#if !defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
     void onConnect(BLEServer* pServer, esp_ble_gatts_cb_param_t *param) {
       pServer->updateConnParams(param->connect.remote_bda,PhyphoxBLE::minConInterval,PhyphoxBLE::maxConInterval,PhyphoxBLE::slaveLatency,PhyphoxBLE::timeout);
       PhyphoxBLE::currentConnections+=1;
     };
-
+#else
+    void onConnect(BLEServer* pServer) {
+      uint16_t connId = pServer->getConnId();
+      pServer->updateConnParams(connId, PhyphoxBLE::minConInterval, PhyphoxBLE::maxConInterval, PhyphoxBLE::slaveLatency, PhyphoxBLE::timeout);
+      PhyphoxBLE::currentConnections+=1;
+    };
+#endif
     void onDisconnect(BLEServer* pServer) {
       PhyphoxBLE::disconnected();
       PhyphoxBLE::currentConnections-=1;


### PR DESCRIPTION
Fix BLE connection parameters for NimBLE-based ESP32 boards

When using ESP32 boards that utilize NimBLE (like Adafruit Feather ESP32 S3 TFT), the compilation fails due to missing BLE types from the ESP-IDF BLE stack. This occurs because NimBLE uses a different API structure compared to the Bluedroid ESP32 BLE stack.

Error messages:

```
home/bob/Arduino/libraries/phyphox_BLE/src/phyphoxBLE_ESP32.cpp:107:40: error: 'esp_ble_gatts_cb_param_t' has not been declared
  107 |     void onConnect(BLEServer* pServer, esp_ble_gatts_cb_param_t *param) {
      |                                        ^~~~~~~~~~~~~~~~~~~~~~~~
/home/bob/Arduino/libraries/phyphox_BLE/src/phyphoxBLE_ESP32.cpp: In member function 'void MyServerCallbacks::onConnect(BLEServer*, int*)':
/home/bob/Arduino/libraries/phyphox_BLE/src/phyphoxBLE_ESP32.cpp:108:40: error: request for member 'connect' in '* param', which is of non-class type 'int'
  108 |       pServer->updateConnParams(param->connect.remote_bda,PhyphoxBLE::minConInterval,PhyphoxBLE::maxConInterval,PhyphoxBLE::slaveLatency,PhyphoxBLE::timeout);
      |                                        ^~~~~~~
exit status 1
```


The fix implements a conditional compilation block that uses the NimBLE-specific connection API when CONFIG_BT_NIMBLE_ROLE_PERIPHERAL is defined.